### PR TITLE
Fix for MatrixSymbol and Export stuck issue in Mathematica (Wolfram?) v14

### DIFF
--- a/Core/ExtractVertexTools.m
+++ b/Core/ExtractVertexTools.m
@@ -123,7 +123,10 @@ ToCheckOperatorChain[expr_] := Module[{output,temp},
     If[Not[Head[expr] === Times||Head[expr] === Power], Message[CheckOpChain::Head]; Abort[]];
     output = If[Head[expr]===Times,ToOperatorChain @@ expr,ToOperatorChain[expr]]];
 
-
+(* Bug fix for: https://github.com/FeynRules/FeynRules/issues/5 *)
+FR$ReprotectCommutator = MemberQ[Attributes[Commutator], Protected];
+If[FR$ReprotectCommutator, Unprotect[Commutator]];
+(* Bug fix end *)
 
 (* ::Section:: *)
 (*Commutation relations*)
@@ -139,6 +142,10 @@ Commutator[psi1_, crea[psi2_, inds_, i_]] := KronDelta[psi1, psi2, inds] * uwave
 delCom[Except[_uwave, a_] uwave[psi1_,i__], mu_] := a delCom[uwave[psi1,i], mu];
 delCom[uwave[psi1_,inds___, k_], mu_] := - I FV[k,mu]uwave[psi1,inds,k];
 delCom[0, _] := 0;
+
+(* Bug fix for: https://github.com/FeynRules/FeynRules/issues/5 *)
+If[FR$ReprotectCommutator, Protect[Commutator]];
+(* Bug fix end *)
 
 
 (* ::Section:: *)

--- a/Core/MassDiagonalization.m
+++ b/Core/MassDiagonalization.m
@@ -1324,6 +1324,10 @@ BlockName[id_] := Block[{resu,mmix},
 (* ::Subsection::Closed:: *)
 (*Getting back a matrix symbol*)
 
+(* Bug fix for: https://github.com/FeynRules/FeynRules/issues/3 *)
+FR$ReprotectMatrixSymbol = MemberQ[Attributes[MatrixSymbol], Protected];
+If[FR$ReprotectMatrixSymbol, Unprotect[MatrixSymbol]];
+(* Bug fix end *)
 
 MatrixSymbol[id_,S]:=MatrixSymbol[id,"S"];
 MatrixSymbol[id_,PS]:=MatrixSymbol[id,"PS"];
@@ -1350,6 +1354,10 @@ MatrixSymbol[id_] := Block[{resu},
   If[Type[id]==="F4", Message[MassDiag::GBFLR]; Abort[]];
   Return[MixingMatrix/.FR$MixingRules[Mix[id]]/.MixingMatrix->"No matrix symbol found."];
 ];
+
+(* Bug fix for: https://github.com/FeynRules/FeynRules/issues/3 *)
+If[FR$ReprotectMatrixSymbol, Protect[MatrixSymbol]];
+(* Bug fix end *)
 
 
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
It seems `Mathematica (Wolfram?) v14` started protecting some symbols (`Commutator`, `MatrixSymbol`), which broke the custom definitions referenced in #3 and #5. 

This fix temporarily unprotects them while `FeynRules` uses it, then restores their protection. 

Tested on `Mathematica (Wolfram?) 14.3` + `macOS 26.1` (default `SM.nb` exports complete without warnings).